### PR TITLE
CxxToolchainInfo with linker = "riscv64-linux-gnu-gcc"

### DIFF
--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,17 +1,23 @@
-load(":riscv_rust_toolchain.bzl", "riscv_rust_toolchain")
+load(":riscv_rust_toolchain.bzl", "riscv_cxx_toolchain", "riscv_rust_toolchain")
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
 
-system_cxx_toolchain(
+riscv_cxx_toolchain(
     name = "cxx",
+    base = ":cxx_host",
+    linker = "riscv64-linux-gnu-gcc",
+    linker_type = "gnu",
     visibility = ["PUBLIC"],
+)
+
+system_cxx_toolchain(
+    name = "cxx_host",
 )
 
 system_python_bootstrap_toolchain(
     name = "python_bootstrap",
     visibility = ["PUBLIC"],
 )
-
 
 riscv_rust_toolchain(
     name = "rust",


### PR DESCRIPTION
Fixes https://github.com/facebook/buck2/issues/895#issuecomment-2799898522.

```console
$ buck2 build //:hello_word --show-simple-output | xargs file
Loading targets.   Remaining     0/13             
Analyzing targets. Remaining     0/50             
Executing actions. Remaining     0/7              
Command: build.    Finished 1 local                                                                                   
Time elapsed: 0.8s
BUILD SUCCEEDED

buck-out/v2/gen/root/904931f735703749/__hello_word__/hello_word: ELF 64-bit LSB pie executable, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, BuildID[sha1]=df1242819dbb0674653127658e16c76826b42aaf, for GNU/Linux 4.15.0, with debug_info, not stripped
```